### PR TITLE
release: BN2015 dashboard + ASD pragmatics meta metrics (docs + README_JA)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,34 +1,22 @@
-# ---- secrets / env
-.venv/
-.env
-__pycache__/
+# virtual env / caches
+.venv*/ 
+__pycache__/ 
+*.pyc
+
+# local / large outputs
+out/
+reports/
+tmp_*/ 
+*.xlsx
+
+# raw & processed data are NOT tracked (we keep just a placeholder)
+data/*
+!data/README.md
+!data/processed/.gitkeep
+
+# editor backups / macOS
+*~ 
 .DS_Store
 
-# ---- raw data (絶対に公開しない)
-data/raw/
-data/raw_mvp/
-data/interim/
-data/processed/
-data/audio/
-
-# ---- unpacked corpora folders（誤って直置きした場合に備え）
-Brown/
-Sachs/
-Nadig/
-Rollins/
-Flusberg/
-Providence/
-
-# ---- file types to avoid
-*.cha
-*.wav
-*.zip
-*.gz
-
-# ---- generated artifacts（必要なら後で外す）
-reports/corpus_manifest.csv
-reports/baseline_report.json
-reports/figures/top_features.png
-
-# local backups
-*.bak
+# accidental copies (日本語の「コピー」など)
+*コピー*

--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,20 @@ show_repro:
 # 4) 再現物クリーン
 clean_repro:
 	rm -rf $(REPRO_DIR) $(REPRO_HTML) $(REPRO_LOG)
+# ==== Pragmatics add-on (non-invasive) ====
+PRAG_MOD  := src/features/pragmatics_basic.py
+PRAG_IN   := data/interim/utterances.csv
+PRAG_OUT  := data/processed/pragmatics_basic.csv
+DASH_HTML := docs/bn2015_dashboard.html
+
+pragmatics_basic:
+	python $(PRAG_MOD) --in_csv $(PRAG_IN) --out_csv $(PRAG_OUT)
+
+dashboard_plus:  ## requires reproduce_bn2015 to have produced dyads/desc/ttest
+	python make_dashboard.py \
+		--dyads $(REPRO_DIR)/dyads.csv \
+		--desc $(REPRO_DIR)/table3_descriptives_en.csv \
+		--ttest $(REPRO_DIR)/table2_en_ttests.csv \
+		--out $(DASH_HTML) \
+		--prag $(PRAG_OUT)
+	@echo "Wrote $(DASH_HTML) (add-on section included if $(PRAG_OUT) exists)"

--- a/README_JA.md
+++ b/README_JA.md
@@ -1,0 +1,97 @@
+# BN2015 再現 + 語用論メタ指標ダッシュボード
+
+## 目的
+- 山下先生／和田先生に、**Bang & Nadig (2015; 以下 BN2015)** の英語再現結果と、
+  追加実装した **語用論（Pragmatics）メタ指標**を **1枚のHTML** で見てもらう。
+- **日本語 README** だけ読めば、再現の流れ・指標の定義・出典が分かる。
+
+## 概要
+- 対象データ: TalkBank **Nadig (English, 100番台)**。偶数=ASD, 奇数=TYP。
+- 再現: BN2015 の **T2（9分窓）** を 11/11 subject にそろえて再集計。
+- 追加実装（CHIのみ）:
+  - **Questions（All/WH/Yes-No）** …… *per utter*
+  - **Discourse Markers（Fill/Contrast/Causal/Shift）** …… *per 100 utter*
+  - **Mental-state（総数）** …… *per 100 words*
+  - **メタ解析CSV** …… *mean/sd/n と Hedges’ g（95%CI）*
+
+## フォルダ構成（公開時）
+```
+.
+├─ docs/
+│  ├─ index.html                 # ダッシュボードのリンク
+│  └─ bn2015_dashboard.html      # 生成物（GitHub Pages で公開）
+├─ src/features/
+│  ├─ pragmatics_from_cha.py     # Nadig .cha → CHI の語用論指標を集計（ASD/TYP）
+│  └─ pragmatics_basic.py        # 既存の簡易版（任意）
+├─ make_dashboard.py             # ダッシュボード生成
+├─ dual_bn2015.yaml              # 既存の再現設定
+├─ README_JA.md                  # このファイル
+└─ data/                         # データ置き場（原則リポジトリには含めない）
+   ├─ raw/asd/Nadig/*.cha        # Nadig 英語（取得元から各自取得）
+   └─ processed/                 # スクリプトで再生成できる中間物
+```
+
+## 依存パッケージ（最小）
+```bash
+python -m venv .venv-bn2015
+source .venv-bn2015/bin/activate
+pip install -U pip pandas numpy matplotlib pyyaml
+```
+
+## 再現手順（ローカル）
+
+### 1) CHI の語用論指標を生成（11/11 subject に制限）
+```bash
+python src/features/pragmatics_from_cha.py   --nadig_dir data/raw/asd/Nadig   --restrict_to_dyads dyads.bn2015.full.csv   --out_csv data/processed/pragmatics_child_group.csv   --byfile_out_csv data/processed/pragmatics_child_byfile.csv   --meta_out data/processed/pragmatics_meta.csv
+```
+
+### 2) ダッシュボードを生成（`docs/`に書き出し）
+```bash
+python make_dashboard.py   --dyads dyads.bn2015.full.csv   --desc  out/bn2015/table3_descriptives_en.csv   --ttest out/bn2015/table2_en_ttests.csv   --out   docs   --prag_child_grp data/processed/pragmatics_child_group.csv   --prag_meta      data/processed/pragmatics_meta.csv
+```
+
+- 生成された **docs/bn2015_dashboard.html** を GitHub Pages で公開（下記参照）。
+
+## GitHub Pages で公開
+1. GitHub の **Settings → Pages** を開く  
+2. **Source: “Deploy from a branch”**, **Branch: `main` / Folder: `/docs`** を選択  
+3. 保存後、数十秒で公開URL（`https://<user>.github.io/<repo>/`）が発行
+
+## 語用論の指標定義（CHI）
+- Questions（All / WH / Yes-No）:  
+  - All = WH ∪ Yes-No、分母は CHI の発話数 `n_utt`、単位 *per utter*
+- Discourse Markers: Fill / Contrast / Causal / Shift（単位 *per 100 utter*）  
+  - **Contrast 辞書**（拡張済）:  
+    `but, however, though, although, yet, whereas, instead, but then, even so, on the other hand,
+     in contrast, nevertheless, nonetheless, still`
+- Mental-state（Total /100w）: 心的状態語（動詞・形容詞・名詞）の合計 / 100語
+
+### 解析ロジック（要点）
+- 対象: CHI のみ。100番台（英語）のみ採用。**偶数=ASD / 奇数=TYP**。
+- 被験者内に複数 .cha がある場合は **被験者内平均 → 群平均**（等重み）。
+- BN2015 再現の 11/11 subject へ **`--restrict_to_dyads`** で合わせる。
+
+## メタ解析CSV（`data/processed/pragmatics_meta.csv`）
+- 各指標ごとに **mean/sd/n（ASD/TYP）** と **Hedges’ g, 95%CI** を出力。
+- 例（ヘッダ）:  
+  `metric,mean_ASD,sd_ASD,n_ASD,mean_TYP,sd_TYP,n_TYP,hedges_g,se,ci95_lo,ci95_hi`
+
+## 出典・クレジット
+- **Bang, J. Y., & Nadig, A. (2015)**. *Maternal input…*（英語コーパス／T2再現のベース）  
+- **TalkBank Nadig corpus**: <https://talkbank.org/asd/access/English/Nadig.html>  
+- **レビュー論文（3本）**: ASD の言語・語用論/韻律/意味などの総説。**本ダッシュボードの語用論指標は、これらの要約に基づく**。  
+  （※ DOI/正式書誌情報は後で追記予定）
+
+## ライセンス / データ取り扱い
+- このリポジトリの **コードは MIT ライセンス** を想定。データは含めません。
+- コーパスは各提供元のライセンスに従い、各自で取得してください。
+
+## よくある質問（FAQ）
+- **Contrast が 0 になる**: CHI では低頻度。辞書は上記の語を網羅的に検索。0 は“未検出”=実測ゼロ。
+- **n_dyads が 13/25 になる**: `--restrict_to_dyads` で 11/11 に制限した CSV を再生成してからダッシュボードを作ってください。
+
+---
+
+### 開発メモ（ブランチ運用の提案）
+- 公開用に `release/prag-dashboard-v1` ブランチを作り、**コード + docs + README** のみをコミット。
+- `data/` や `out/` の生成物は追跡しない（`.gitignore` 参照）。

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,3 @@
+# data ディレクトリの扱い
+- `data/raw`: TalkBank (Nadig) など **外部配布NG/大容量**のデータは含めません。取得元: https://talkbank.org/asd/access/English/Nadig.html
+- `data/processed`: スクリプトで再生成できる中間物。原則としてリポジトリには含めません（.gitignore で除外）。必要な最終アウトプットは `docs/` にHTMLとして公開します。

--- a/docs/bn2015_dashboard.html
+++ b/docs/bn2015_dashboard.html
@@ -1,0 +1,72 @@
+<!doctype html><meta charset='utf-8'>
+
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Hiragino Kaku Gothic ProN", Meiryo, sans-serif; margin:24px; }
+h1 { font-size: 22px; margin: 0 0 12px; }
+h2 { font-size: 18px; margin: 18px 0 8px; }
+h3 { font-size: 16px; margin: 12px 0 6px; }
+.muted { color: #777; }
+.tbl { border-collapse: collapse; width: 100%; margin: 6px 0 16px; font-size: 13px; }
+.tbl th, .tbl td { border: 1px solid #ddd; padding: 6px 8px; text-align: right; }
+.tbl th { background: #f6f6f6; text-align: center; }
+.tbl td:first-child, .tbl th:first-child { text-align: left; }
+.small { font-size: 12px; }
+.bad { background: #ffe5e5; }
+.good { background: #e8f7e8; }
+.note { font-size: 12px; color:#555; margin: 6px 0 14px; }
+.kbd { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; background:#f3f3f3; border:1px solid #ddd; padding:0 4px; border-radius:3px; }
+.hr { height:1px; background:#eee; margin:18px 0; }
+</style>
+
+<h1>BN2015 再現ダッシュボード（英語）</h1>
+<div class="muted small">このページは毎回CSVを読み直して再生成されます（make_dashboard.py 内に調整も内蔵）。</div>
+<div class="note">T3 available: <span class="kbd">False</span></div>
+<h2>Figure 1: Input MLU (T2) × MCDI % Spoken (T3)</h2>
+<div class="muted">T3（MCDI %spoken）が未提供のため、Figure 1 を省略しました。</div>
+<div class="note">T3 がない場合は注意文を表示します。</div>
+<div class="hr"></div>
+<h2>Summary</h2>
+<h3>Counts by language × group</h3>
+<table class="tbl">
+<thead><tr><th>language</th><th>diagnostic_group</th><th>n</th></tr></thead>
+<tbody>
+<tr><td>EN</td><td>ASD</td><td>11</td></tr>
+<tr><td>EN</td><td>TYP</td><td>11</td></tr>
+</tbody></table>
+<div class="hr"></div>
+<h2>Group Comparison (EN, ASD vs TYP)</h2>
+<h3>EN Welch t-tests (ASD vs TYP)</h3>
+<div class="muted">（データなし）</div>
+<div class="hr"></div>
+<h2>Descriptives (EN)</h2>
+<h3>EN Descriptives</h3>
+<div class="muted">（データなし）</div>
+<div class="hr"></div>
+<h2>Paper Comparison (EN)</h2>
+<h3>Paper vs Ours (EN) — Table 1 metrics</h3>
+<div class="muted">Descriptives not available (missing columns: group/column/mean/sd).</div>
+<h3>Paper vs Ours (EN) — Table 2 metrics</h3>
+<div class="muted">Descriptives not available (missing columns: group/column/mean/sd).</div>
+<div class="hr"></div>
+<h2>Pragmatics Basic — Questions / Discourse Markers / Mental-state</h2>
+<table class="tbl">
+<thead><tr><th>Metric</th><th>CHI</th><th>MOT</th></tr></thead>
+<tbody>
+<tr><td>Questions (All) — per utter</td><td>0.099</td><td></td></tr>
+<tr><td>WH Questions — per utter</td><td>0.058</td><td></td></tr>
+<tr><td>Yes/No Questions — per utter</td><td>0.041</td><td></td></tr>
+<tr><td>DM: Fill — /100 utt</td><td>1.527</td><td></td></tr>
+<tr><td>DM: Contrast — /100 utt</td><td>0.414</td><td></td></tr>
+<tr><td>DM: Causal — /100 utt</td><td>0.623</td><td></td></tr>
+<tr><td>DM: Shift — /100 utt</td><td>0.003</td><td></td></tr>
+<tr><td>Mental-state (Total) — /100 w</td><td>1.05</td><td></td></tr>
+</tbody></table>
+<div class="hr"></div>
+<h3>Source CSVs</h3>
+<table class="tbl">
+<thead><tr><th>file</th><th>path</th></tr></thead>
+<tbody>
+<tr><td>table2_en_ttests.csv</td><td>table2_en_ttests.csv</td></tr>
+<tr><td>table3_descriptives_en.csv</td><td>table3_descriptives_en.csv</td></tr>
+<tr><td>dyads.csv</td><td>dyads.9min.ndw_strict.patched.csv</td></tr>
+</tbody></table>

--- a/dual_bn2015.yaml
+++ b/dual_bn2015.yaml
@@ -58,3 +58,19 @@ docs:
   publish_csv: true                 # 追加: CSVをdocs配下にミラー公開
   csv_public_dir: "docs/assets/bn2015"  # 追加: 公開先ディレクトリ
 
+features:
+  pragmatics_basic:
+    enabled: true
+    module: src/features/pragmatics_basic.py
+    input: data/interim/utterances.csv
+    output: data/processed/pragmatics_basic.csv
+    speakers: [CHI, MOT]
+    normalize:
+      per100w: [ms_v, ms_a, ms_n, ms_total]
+      per100utt: [dm_fill, dm_contrast, dm_causal, dm_shift]
+    rates_per_utt: [q_all, q_wh, q_yn]
+assemble:
+  join:
+    - base: data/processed/core_metrics.csv   # 既存（MLU/TTR/NDW@N等）
+    - add:  data/processed/pragmatics_basic.csv
+      on: speaker

--- a/make_dashboard.py
+++ b/make_dashboard.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+BN2015（英語）ダッシュボード生成スクリプト（最終版）
+
+機能:
+- 既存の再現出力（dyads/desc/ttest）を表示
+- Pragmatics（CHIのみ、ASD vs TYP）は --prag_child_grp の CSV を表示
+- Pragmatics のメタ解析CSV（mean/sd/n + Hedges g, 95%CI）をそのまま全カラム表示（--prag_meta）
+- T3 があれば Figure1 (Input MLU × T3 %spoken) を描画
+- Paper Comparison（Table 1/2）を表示
+- 出力先 --out がディレクトリなら {out}/bn2015_dashboard.html に保存
+
+使い方例:
+python make_dashboard.py \
+  --dyads dyads.bn2015.full.csv \
+  --desc  out/bn2015/table3_descriptives_en.csv \
+  --ttest out/bn2015/table2_en_ttests.csv \
+  --out   out/bn2015 \
+  --prag_child_grp data/processed/pragmatics_child_group.csv \
+  --prag_meta      data/processed/pragmatics_meta.csv
+"""
+import argparse
+import os
+import math
+import re
+import pandas as pd
+import numpy as np
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+# ===== 論文（英語列）の目標値（Paper Comparison 用） =====
+PAPER_T1 = {  # Table 1 (child@T2)
+    ("ASD","T2_child_word_types"): (48.46, 42.48),
+    ("TYP","T2_child_word_types"): (59.00, 34.36),
+    ("ASD","T2_age_months"):       (61.89, 10.99),
+    ("TYP","T2_age_months"):       (32.30,  8.43),
+}
+PAPER_T2 = {  # Table 2 (maternal input@T2)
+    ("ASD","input_word_tokens"):     (664.64, 328.94),
+    ("TYP","input_word_tokens"):     (1126.36, 222.29),
+    ("ASD","input_word_types"):      (142.64, 29.80),
+    ("TYP","input_word_types"):      (146.46, 39.37),
+    ("ASD","input_mlu"):             (4.75, 0.92),
+    ("TYP","input_mlu"):             (5.40, 0.81),
+    ("ASD","input_num_utterances"):  (112.36, 58.62),
+    ("TYP","input_num_utterances"):  (112.36, 37.43),
+}
+
+HTML_CSS = """
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Hiragino Kaku Gothic ProN", Meiryo, sans-serif; margin:24px; }
+h1 { font-size: 22px; margin: 0 0 12px; }
+h2 { font-size: 18px; margin: 18px 0 8px; }
+h3 { font-size: 16px; margin: 12px 0 6px; }
+.muted { color: #777; }
+.tbl { border-collapse: collapse; width: 100%; margin: 6px 0 16px; font-size: 13px; }
+.tbl th, .tbl td { border: 1px solid #ddd; padding: 6px 8px; text-align: right; }
+.tbl th { background: #f6f6f6; text-align: center; }
+.tbl td:first-child, .tbl th:first-child { text-align: left; }
+.small { font-size: 12px; }
+.note { font-size: 12px; color:#555; margin: 6px 0 14px; }
+.hr { height:1px; background:#eee; margin:18px 0; }
+.kbd { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; background:#f3f3f3; border:1px solid #ddd; padding:0 4px; border-radius:3px; }
+</style>
+"""
+
+# ---------- utils ----------
+def parse_args():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dyads", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--desc", required=True)
+    ap.add_argument("--ttest", required=True)
+    ap.add_argument("--prag_child_grp", default="", help="ASD/TYP group means (CHI only), e.g., data/processed/pragmatics_child_group.csv")
+    ap.add_argument("--prag_meta", default="", help="meta-analysis CSV (e.g., data/processed/pragmatics_meta.csv)")
+    return ap.parse_args()
+
+def to_html_table(df: pd.DataFrame, round_float=True) -> str:
+    if df is None or len(df) == 0:
+        return '<div class="muted">（データなし）</div>'
+    df = df.copy()
+    if round_float:
+        for c in df.columns:
+            if pd.api.types.is_float_dtype(df[c]):
+                df[c] = df[c].apply(lambda v: "" if pd.isna(v) else (int(v) if float(v).is_integer() else round(float(v), 3)))
+    cols = list(df.columns)
+    html = ['<table class="tbl">']
+    html.append("<thead><tr>" + "".join(f"<th>{c}</th>" for c in cols) + "</tr></thead>")
+    html.append("<tbody>")
+    for _, row in df.iterrows():
+        html.append("<tr>" + "".join(f"<td>{row[c]}</td>" for c in cols) + "</tr>")
+    html.append("</tbody></table>")
+    return "\n".join(html)
+
+def smart_read_csv(path_or_empty: str, basename_hint: str = "") -> pd.DataFrame:
+    """
+    与えられたパスが無い場合に、よくある場所を探索して読む。
+    """
+    cands = []
+    if path_or_empty:
+        cands.append(path_or_empty)
+        cands.append(os.path.basename(path_or_empty))
+    if basename_hint:
+        cands.append(basename_hint)
+    base = os.path.basename(path_or_empty or basename_hint)
+    for root in ["", "data/processed", "out/bn2015", "reports/reproduction/bang_nadig_2015", "."]:
+        if base:
+            cands.append(os.path.join(root, base))
+    seen = set()
+    for p in cands:
+        if not p or p in seen:
+            continue
+        seen.add(p)
+        if os.path.exists(p):
+            try:
+                print(f"[INFO] read_csv: {p}")
+                return pd.read_csv(p)
+            except Exception as e:
+                print(f"[WARN] Failed to read {p}: {e}")
+    if path_or_empty:
+        print(f"[WARN] CSV not found: {path_or_empty}")
+    return pd.DataFrame()
+
+def clean_desc_ranges(df: pd.DataFrame) -> pd.DataFrame:
+    """descのrange列を (xx.xx, yy.yy) へ整形し、NaNはダッシュに。"""
+    if df is None or df.empty or "range" not in df.columns:
+        return df
+    def _fmt(x):
+        s = str(x)
+        if "nan" in s.lower():
+            return "—"
+        nums = re.findall(r"[-+]?\d*\.\d+|\d+", s)
+        if len(nums) >= 2:
+            a, b = float(nums[0]), float(nums[1])
+            return f"({a:.2f}, {b:.2f})"
+        return s
+    out = df.copy()
+    out["range"] = out["range"].apply(_fmt)
+    return out
+
+# ---------- paper comparison ----------
+def paper_compare_block(desc_df: pd.DataFrame, which="T1"):
+    """desc_df から group×column の mean/sd を拾い、PAPER_* と比較テーブルを生成"""
+    if desc_df is None or desc_df.empty or not {"group","column","mean","sd"} <= set(desc_df.columns):
+        return '<div class="muted">（記述統計CSVが見つからない/列不足のため比較を省略）</div>'
+    paper = PAPER_T1 if which=="T1" else PAPER_T2
+    rows = []
+    for (grp, col), (p_mean, p_sd) in paper.items():
+        sub = desc_df[(desc_df["group"]==grp) & (desc_df["column"]==col)]
+        if len(sub)==0:
+            rows.append({"measure": col, "group": grp, "mine_mean":"", "paper_mean":p_mean,
+                         "Δmean": "", "Δmean%": "", "mine_sd":"", "paper_sd": p_sd, "Δsd":"", "Δsd%": ""})
+            continue
+        mine_mean = float(sub["mean"].values[0])
+        mine_sd   = float(sub["sd"].values[0]) if not pd.isna(sub["sd"].values[0]) else np.nan
+        dmean = mine_mean - p_mean
+        dmean_pct = (dmean / p_mean * 100.0) if p_mean else np.nan
+        dsd = (mine_sd - p_sd) if not np.isnan(mine_sd) else np.nan
+        dsd_pct = (dsd / p_sd * 100.0) if p_sd else np.nan
+        rows.append({
+            "measure": col, "group": grp,
+            "mine_mean": round(mine_mean, 3), "paper_mean": p_mean,
+            "Δmean": round(dmean, 2), "Δmean%": round(dmean_pct, 2) if not np.isnan(dmean_pct) else "",
+            "mine_sd": round(mine_sd, 3) if not np.isnan(mine_sd) else "",
+            "paper_sd": p_sd,
+            "Δsd": round(dsd, 2) if not np.isnan(dsd) else "",
+            "Δsd%": round(dsd_pct, 2) if not np.isnan(dsd_pct) else "",
+        })
+    out = pd.DataFrame(rows, columns=["measure","group","mine_mean","paper_mean","Δmean","Δmean%","mine_sd","paper_sd","Δsd","Δsd%"])
+    return to_html_table(out)
+
+# ---------- main ----------
+def main():
+    args = parse_args()
+
+    # 出力パス（ファイル or ディレクトリ）
+    if args.out.lower().endswith(".html"):
+        out_dir = os.path.dirname(args.out) or "."
+        out_html = args.out
+    else:
+        out_dir = args.out
+        out_html = os.path.join(out_dir, "bn2015_dashboard.html")
+    os.makedirs(out_dir, exist_ok=True)
+
+    # 入力読み込み
+    dy = pd.read_csv(args.dyads)
+    desc_raw = smart_read_csv(args.desc, basename_hint="table3_descriptives_en.csv")
+    ttest = smart_read_csv(args.ttest, basename_hint="table2_en_ttests.csv")
+    prag = smart_read_csv(args.prag_child_grp, basename_hint="pragmatics_child_group.csv")
+    prag_meta = smart_read_csv(args.prag_meta, basename_hint="pragmatics_meta.csv")
+
+    # Descriptives 整形（range・NaNの見た目）
+    desc = clean_desc_ranges(desc_raw)
+
+    # Figure 1（T3あれば）
+    if "T3_mcdi_pct_spoken" in dy.columns and "input_mlu" in dy.columns:
+        tmp = dy[["input_mlu","T3_mcdi_pct_spoken"]].copy()
+        tmp["input_mlu"] = pd.to_numeric(tmp["input_mlu"], errors="coerce")
+        tmp["T3_mcdi_pct_spoken"] = pd.to_numeric(tmp["T3_mcdi_pct_spoken"], errors="coerce")
+        tmp = tmp.dropna()
+        if len(tmp) > 0:
+            fig_path = os.path.join(out_dir, "figure1_mlu_vs_mcdi_updated.png")
+            plt.figure(figsize=(6,4))
+            plt.scatter(tmp["input_mlu"], tmp["T3_mcdi_pct_spoken"])
+            plt.xlabel("Maternal Input MLU (T2)")
+            plt.ylabel("Child Vocabulary 6 Months Later (MCDI, %spoken)")
+            plt.tight_layout(); plt.savefig(fig_path, dpi=150); plt.close()
+            fig1_html = f'<img src="{os.path.basename(fig_path)}" style="max-width:100%;">'
+        else:
+            fig1_html = '<div class="muted">T3 は列はありますが、数値が欠損のためプロットできません。</div>'
+    else:
+        fig1_html = '<div class="muted">T3（MCDI %spoken）または input_mlu が未提供のため、Figure 1 を省略します。</div>'
+
+    # 言語×群の件数
+    if {"language","diagnostic_group","dyad_id"} <= set(dy.columns):
+        counts = dy.groupby(["language","diagnostic_group"], as_index=False)["dyad_id"].count().rename(columns={"dyad_id":"n"})
+    else:
+        # セーフティ: 必要列が無い場合は全件数だけ出す
+        tmp = pd.DataFrame({"n":[len(dy)]})
+        counts = tmp
+
+    # Pragmatics（ASD/TYP, CHIのみ）
+    if not prag.empty:
+        # group列 or index を正規化
+        if "group" in prag.columns:
+            prag = prag.set_index("group")
+        if "n_dyads" in prag.columns:
+            try:
+                prag["n_dyads"] = prag["n_dyads"].astype("Int64")  # 小数見せ防止
+            except Exception:
+                pass
+        rename = {
+            "n_dyads":"n_dyads",
+            "q_all_rate":"Questions (All) — per utter",
+            "q_wh_rate":"WH Questions — per utter",
+            "q_yn_rate":"Yes/No Questions — per utter",
+            "dm_fill_per100utt":"DM: Fill — /100 utt",
+            "dm_contrast_per100utt":"DM: Contrast — /100 utt",
+            "dm_causal_per100utt":"DM: Causal — /100 utt",
+            "dm_shift_per100utt":"DM: Shift — /100 utt",
+            "ms_total_per100w":"Mental-state (Total) — /100 w",
+        }
+        cols = [c for c in ["n_dyads","q_all_rate","q_wh_rate","q_yn_rate",
+                            "dm_fill_per100utt","dm_contrast_per100utt","dm_causal_per100utt","dm_shift_per100utt",
+                            "ms_total_per100w"] if c in prag.columns]
+        order_groups = [g for g in ["ASD","TYP"] if g in prag.index]
+        tidy = prag.loc[order_groups, cols].T.reset_index().rename(columns={"index":"Metric"})
+        tidy["Metric"] = tidy["Metric"].map(lambda k: rename.get(k, k))
+        prag_html = to_html_table(tidy)
+    else:
+        prag_html = '<div class="muted">pragmatics_child_group.csv が見つからないため、このセクションは省略します。（--prag_child_grp のパスを確認）</div>'
+
+    # Pragmatics meta 表
+    if not prag_meta.empty:
+        meta_cols = [c for c in [
+            "metric","mean_ASD","sd_ASD","n_ASD",
+            "mean_TYP","sd_TYP","n_TYP",
+            "hedges_g","se","ci95_lo","ci95_hi"
+        ] if c in prag_meta.columns]
+        meta_html = to_html_table(prag_meta[meta_cols])
+    else:
+        meta_html = '<div class="muted">pragmatics_meta.csv が見つからないため、このセクションは省略します。（--prag_meta のパスを確認）</div>'
+
+    # t-tests / desc HTML
+    ttest_html = to_html_table(ttest)
+    desc_html  = to_html_table(desc)
+    counts_html= to_html_table(counts)
+
+    # Paper Comparison
+    pc_t1_html = paper_compare_block(desc_raw, which="T1")
+    pc_t2_html = paper_compare_block(desc_raw, which="T2")
+
+    # HTML 組み立て
+    html = []
+    html.append("<!doctype html><meta charset='utf-8'>")
+    html.append(HTML_CSS)
+    html.append("<h1>BN2015 再現ダッシュボード（英語）</h1>")
+    html.append('<div class="note">このページは make_dashboard.py で再生成されます。</div>')
+
+    html.append("<h2>Figure 1: Input MLU (T2) × MCDI % Spoken (T3)</h2>")
+    html.append(fig1_html)
+
+    html.append('<div class="hr"></div>')
+    html.append("<h2>Summary</h2>")
+    html.append("<h3>Counts by language × group</h3>")
+    html.append(counts_html)
+
+    html.append('<div class="hr"></div>')
+    html.append("<h2>Group Comparison (EN, ASD vs TYP)</h2>")
+    html.append("<h3>EN Welch t-tests (ASD vs TYP)</h3>")
+    html.append(ttest_html)
+
+    html.append('<div class="hr"></div>')
+    html.append("<h2>Descriptives (EN)</h2>")
+    html.append(desc_html)
+
+    html.append('<div class="hr"></div>')
+    html.append("<h2>Paper Comparison (EN)</h2>")
+    html.append("<h3>Paper vs Ours — Table 1 metrics</h3>")
+    html.append(pc_t1_html)
+    html.append("<h3>Paper vs Ours — Table 2 metrics</h3>")
+    html.append(pc_t2_html)
+
+    html.append('<div class="hr"></div>')
+    html.append("<h2>Pragmatics (CHI) — ASD vs TYP</h2>")
+    html.append("<div class='note'>Nadig英語（100番台）、偶数=ASD/奇数=TYP。BN2015で使用した 11/11 subject のみを集計。指標の単位: per utter / per 100 utt / per 100 w。</div>")
+    html.append("<div class='note'>Contrast は CHI では低頻度です。辞書（but/however/though/although/yet/whereas/instead/but then/even so/on the other hand/in contrast/nevertheless/nonetheless/still）で探索済み。0 は“未検出”=実測ゼロを意味します。</div>")
+    html.append(prag_html)
+
+    html.append('<div class="hr"></div>')
+    html.append("<h2>Pragmatics — Meta metrics (ASD vs TYP)</h2>")
+    html.append("<div class='note'>各指標の mean/sd/n と Hedges g（Hedges' g）, 95%CI を CSV そのまま掲載します。</div>")
+    html.append(meta_html)
+
+    # ソースファイル一覧（ベース名だけ表示）
+    html.append('<div class="hr"></div>')
+    src_tbl = pd.DataFrame({
+        "file": ["table2_en_ttests.csv","table3_descriptives_en.csv","dyads.csv",
+                 "pragmatics_child_group.csv","pragmatics_meta.csv"],
+        "path": [os.path.basename(args.ttest), os.path.basename(args.desc), os.path.basename(args.dyads),
+                 os.path.basename(args.prag_child_grp) if args.prag_child_grp else "",
+                 os.path.basename(args.prag_meta) if args.prag_meta else ""],
+    })
+    html.append("<h3>Source CSVs</h3>")
+    html.append(to_html_table(src_tbl, round_float=False))
+
+    with open(out_html, "w", encoding="utf-8") as w:
+        w.write("\n".join(html))
+    print(f"Wrote: {out_html}")
+
+if __name__ == "__main__":
+    main()

--- a/src/features/pragmatics_basic.py
+++ b/src/features/pragmatics_basic.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+"""
+Pragmatics Basic features (low-cost), with two outputs:
+  A) speaker summary (legacy): CHI/MOT aggregated over all data -> --out_csv
+  B) child-group summary (NEW): CHI per dyad -> ASD/TYP means -> --group_out_csv
+
+Inputs:
+  --in_csv: utterances.csv (needs: speaker, one of {text, utterance, utt}; optional keys like dyad_id/child_uid/file)
+  --dyads : dyads.csv with a join key (e.g., dyad_id/child_uid/file) and a group column (diagnostic_group/group/dx/...)
+Outputs:
+  --out_csv       : speaker-level summary (kept for backward-compat)
+  --group_out_csv : child (CHI) ASD/TYP summary
+
+You can override join keys:
+  --utter_key child_uid --dyads_key child_uid
+Or rely on auto-detection priority:
+  dyad_id -> child_uid -> mother_uid -> file
+"""
+import re, argparse
+import pandas as pd
+
+WH_RE = re.compile(r'^\s*(who|what|why|how|when|where|which|whose)\b', re.I)
+QMARK_RE = re.compile(r'\?\s*$')
+TOKEN_RE = re.compile(r"[A-Za-z]+(?:'[A-Za-z]+)?")
+
+DM_LEX = {
+    "fill":     [r"you know", r"i mean", r"well", r"like"],
+    "contrast": [r"but", r"however", r"though", r"although"],
+    "causal":   [r"because", r"so\b", r"therefore", r"thus", r"since\b"],
+    "shift":    [r"anyway", r"by the way", r"now,", r"ok,", r"okay,"],
+}
+DM_PAT = {k: re.compile(r"\b(?:%s)\b" % "|".join(v), re.I) for k, v in DM_LEX.items()}
+
+MS_VERBS = {"think","know","believe","guess","remember","forget","feel","want","hope",
+            "pretend","notice","decide","understand","suppose","realize","wish","doubt"}
+MS_ADJS  = {"sure","afraid","glad","sorry","certain","uncertain","anxious","confident"}
+MS_NOUNS = {"idea","plan","belief","memory","thought","feeling","desire","hope"}
+
+JOIN_ALIASES = {
+    "dyad_id":   ["dyad_id","dyad","dyad_uid","pair_id","pair_uid","family_id"],
+    "child_uid": ["child_uid","child_id","chi_uid","chi_id","participant_child_uid","participant_uid","child","chi"],
+    "mother_uid":["mother_uid","mom_uid","mother_id","mom_id","mot_uid","mot_id","mother","mot"],
+    "file":      ["file","filename","transcript","cha_file","path","file_id"],
+}
+JOIN_PRIORITY = ["dyad_id","child_uid","mother_uid","file"]
+
+def pick_text_col(df):
+    for c in ["text","utterance","utt"]:
+        if c in df.columns: return c
+    raise ValueError("Input must contain one of: text/utterance/utt")
+
+def count_tokens(s: str) -> int:
+    return len(TOKEN_RE.findall(s or ""))
+
+def ms_counts(text: str):
+    toks = [t.lower() for t in TOKEN_RE.findall(text or "")]
+    v = sum(t in MS_VERBS for t in toks)
+    a = sum(t in MS_ADJS for t in toks)
+    n = sum(t in MS_NOUNS for t in toks)
+    return v, a, n
+
+def dm_hits(cat: str, text: str) -> int:
+    return len(DM_PAT[cat].findall(text or ""))
+
+def per100(x, base, eps=1e-9): return 100.0 * x / (base + eps)
+
+def add_per_utt_flags(df, text_col):
+    df["text_"] = df[text_col].fillna("").astype(str)
+    df["is_whq"]   = df["text_"].str.match(WH_RE)
+    df["is_qmark"] = df["text_"].str.contains(QMARK_RE)
+    df["is_ynq"]   = df["is_qmark"] & (~df["is_whq"])
+    df["is_q_any"] = df["is_whq"] | df["is_ynq"]
+    for k in DM_PAT:
+        df[f"dm_{k}_count"] = df["text_"].apply(lambda s: dm_hits(k, s))
+    df["tok_n"] = df["text_"].apply(count_tokens)
+    ms = df["text_"].apply(ms_counts)
+    df["ms_v"], df["ms_a"], df["ms_n"] = zip(*ms)
+    df["ms_total"] = df["ms_v"] + df["ms_a"] + df["ms_n"]
+    return df
+
+def speaker_summary(df):
+    rows = []
+    for spk, g in df.groupby("speaker", dropna=False):
+        if spk not in ("CHI","MOT"): continue
+        n_utt = len(g); n_tok = int(g["tok_n"].sum())
+        rows.append({
+            "speaker": spk,
+            f"{spk}_q_all_rate": g["is_q_any"].mean(),
+            f"{spk}_q_wh_rate":  g["is_whq"].mean(),
+            f"{spk}_q_yn_rate":  g["is_ynq"].mean(),
+            f"{spk}_dm_fill_per100utt":     per100(int(g["dm_fill_count"].sum()), n_utt),
+            f"{spk}_dm_contrast_per100utt": per100(int(g["dm_contrast_count"].sum()), n_utt),
+            f"{spk}_dm_causal_per100utt":   per100(int(g["dm_causal_count"].sum()), n_utt),
+            f"{spk}_dm_shift_per100utt":    per100(int(g["dm_shift_count"].sum()), n_utt),
+            f"{spk}_ms_v_per100w":     per100(int(g["ms_v"].sum()), n_tok),
+            f"{spk}_ms_a_per100w":     per100(int(g["ms_a"].sum()), n_tok),
+            f"{spk}_ms_n_per100w":     per100(int(g["ms_n"].sum()), n_tok),
+            f"{spk}_ms_total_per100w": per100(int(g["ms_total"].sum()), n_tok),
+            f"{spk}_utt_n": n_utt, f"{spk}_tok_n": n_tok,
+        })
+    return pd.DataFrame(rows).set_index("speaker")
+
+def detect_join_keys(utt_cols, dy_cols, prefer=None):
+    # explicit override
+    if prefer and prefer[0] in utt_cols and prefer[1] in dy_cols:
+        return prefer[0], prefer[1], "explicit"
+    # auto detection across alias families in priority order
+    for fam in JOIN_PRIORITY:
+        u_alias = next((a for a in JOIN_ALIASES[fam] if a in utt_cols), None)
+        d_alias = next((a for a in JOIN_ALIASES[fam] if a in dy_cols), None)
+        if u_alias and d_alias:
+            return u_alias, d_alias, fam
+    return None, None, None
+
+def normalize_group(val: str) -> str:
+    if val is None: return ""
+    s = str(val).strip().lower()
+    if "asd" in s or "autis" in s:
+        return "ASD"
+    if s in {"td","typ","typical","control","ctl"} or "typ" in s:
+        return "TYP"
+    return s.upper()  # best-effort
+
+def child_group_summary(df_chi, dyads, join_u, join_d, group_col):
+    # join key must exist
+    if join_u not in df_chi.columns or join_d not in dyads.columns or group_col not in dyads.columns:
+        return pd.DataFrame()
+    # dyad-level features
+    cols_dm = ["fill","contrast","causal","shift"]
+    dy_rows = []
+    for key, g in df_chi.groupby(join_u):
+        n_utt = len(g); n_tok = int(g["tok_n"].sum())
+        out = {join_u: key}
+        out.update({
+            "q_all_rate": g["is_q_any"].mean(),
+            "q_wh_rate":  g["is_whq"].mean(),
+            "q_yn_rate":  g["is_ynq"].mean(),
+        })
+        for k in cols_dm:
+            out[f"dm_{k}_per100utt"] = per100(int(g[f"dm_{k}_count"].sum()), n_utt)
+        out["ms_total_per100w"] = per100(int(g["ms_total"].sum()), n_tok)
+        dy_rows.append(out)
+    dy = pd.DataFrame(dy_rows)
+
+    # join to groups
+    dj = dy.merge(dyads[[join_d, group_col]], left_on=join_u, right_on=join_d, how="left")
+    dj["group_norm"] = dj[group_col].apply(normalize_group)
+    grp = dj.groupby("group_norm")
+
+    metrics = ["q_all_rate","q_wh_rate","q_yn_rate",
+               "dm_fill_per100utt","dm_contrast_per100utt","dm_causal_per100utt","dm_shift_per100utt",
+               "ms_total_per100w"]
+    rows = []
+    for gname, gg in grp:
+        if gname not in ("ASD","TYP"):  # ignore others
+            continue
+        out = {"group": gname, "n_dyads": int(gg[join_u].nunique())}
+        for m in metrics:
+            out[m] = float(gg[m].mean())
+        rows.append(out)
+    if not rows:
+        return pd.DataFrame()
+    return pd.DataFrame(rows).set_index("group").sort_index()
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in_csv", required=True, help="utterances.csv")
+    ap.add_argument("--out_csv", required=True, help="speaker summary out path")
+    ap.add_argument("--dyads", default="", help="dyads.csv with group labels")
+    ap.add_argument("--group_out_csv", default="", help="child ASD/TYP summary out path")
+    ap.add_argument("--utter_key", default="", help="join key in utterances (e.g., dyad_id/child_uid/file)")
+    ap.add_argument("--dyads_key", default="", help="join key in dyads (e.g., dyad_id/child_uid/file)")
+    ap.add_argument("--group_col", default="diagnostic_group", help="group column in dyads (default: diagnostic_group)")
+    args = ap.parse_args()
+
+    # read utterances
+    df = pd.read_csv(args.in_csv)
+    df["speaker"] = df["speaker"].astype(str)
+    txt = pick_text_col(df)
+    df = add_per_utt_flags(df, txt)
+
+    # (A) speaker summary (legacy)
+    spk = speaker_summary(df)
+    spk.to_csv(args.out_csv, index=True)
+    print(f"[A] Wrote speaker summary: {args.out_csv}  shape={spk.shape}")
+
+    # (B) child (CHI) group summary
+    if not args.group_out_csv:
+        print("[B] Skipped child group summary (no --group_out_csv given)")
+        return
+
+    chi = df[df["speaker"]=="CHI"].copy()
+    if chi.empty:
+        print("[B] Skipped child group summary (no CHI rows)")
+        return
+
+    # read dyads
+    if not args.dyads:
+        print("[B] Skipped child group summary (no --dyads given)")
+        return
+    try:
+        dyads = pd.read_csv(args.dyads)
+    except Exception as e:
+        print(f"[B] Skipped child group summary (failed to read dyads: {e})")
+        return
+
+    # decide join keys
+    prefer = (args.utter_key, args.dyads_key) if (args.utter_key and args.dyads_key) else None
+    join_u, join_d, how = detect_join_keys(set(chi.columns), set(dyads.columns), prefer=prefer)
+
+    if not join_u or not join_d:
+        print(f"[B] Skipped child group summary (no common join key). "
+              f"Utter cols={list(chi.columns)[:20]}..., Dyads cols={list(dyads.columns)[:20]}...")
+        return
+
+    if args.group_col not in dyads.columns:
+        # try common fallbacks
+        for cand in ["group","grp","dx","diagnosis","diag_group","ASD_TD"]:
+            if cand in dyads.columns:
+                args.group_col = cand
+                break
+    if args.group_col not in dyads.columns:
+        print(f"[B] Skipped child group summary (group column '{args.group_col}' not found in dyads). "
+              f"Available={list(dyads.columns)[:20]}...")
+        return
+
+    grp = child_group_summary(chi, dyads, join_u, join_d, args.group_col)
+    if len(grp) > 0:
+        grp.to_csv(args.group_out_csv, index=True)
+        print(f"[B] Wrote child group summary: {args.group_out_csv}  shape={grp.shape}  "
+              f"(join: utter.{join_u} ↔ dyads.{join_d} via {how}, group_col={args.group_col})")
+    else:
+        print("[B] Skipped child group summary (after join/grouping no ASD/TYP rows)")
+if __name__ == "__main__":
+    main()

--- a/src/features/pragmatics_from_cha.py
+++ b/src/features/pragmatics_from_cha.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Nadig (.cha) 直読み → CHI の語用論指標 → ASD/TYP 群平均 + メタ解析用CSV
+
+- 対象: data/raw/asd/Nadig の英語(100番台)のみ、偶数=ASD / 奇数=TYP
+- 解析窓は .cha そのまま（BN2015準拠データで T2の9分窓になっている想定）
+- Subject内に複数 .cha があれば Subject内平均 → 群平均（= 各被験者を等重み）
+
+オプション:
+--restrict_to_dyads で BN2015 の dyads CSV（例: dyads.bn2015.full.csv）を渡すと、
+そこの t2_files_used 等から subject(3桁) を抽出し、その 11/11 のみを集計。
+
+出力:
+  --out_csv           : group(ASD/TYP) × 指標（群平均） + n_dyads
+  --byfile_out_csv    : ファイル明細（デバッグ用）
+  --meta_out          : メタ解析用（各指標ごとの mean/sd/n と Hedges g, 95%CI）
+
+使い方（BN2015の11/11に揃える推奨）:
+  python src/features/pragmatics_from_cha.py \
+    --nadig_dir data/raw/asd/Nadig \
+    --restrict_to_dyads dyads.bn2015.full.csv \
+    --out_csv data/processed/pragmatics_child_group.csv \
+    --byfile_out_csv data/processed/pragmatics_child_byfile.csv \
+    --meta_out data/processed/pragmatics_meta.csv
+"""
+from __future__ import annotations
+import argparse, os, glob, re, math
+import pandas as pd
+import numpy as np
+
+# ===== パターン類 =====
+WH_RE    = re.compile(r'^\s*(who|what|why|how|when|where|which|whose)\b', re.I)
+QMARK_RE = re.compile(r'\?\s*$')
+TOKEN_RE = re.compile(r"[A-Za-z]+(?:'[A-Za-z]+)?")
+
+# Discourse Markers 辞書（Contrast 拡張版）
+DM_LEX = {
+    "fill":     [r"you know", r"i mean", r"well", r"like"],
+    "contrast": [
+        r"but", r"however", r"though", r"although",
+        r"yet", r"whereas", r"instead",
+        r"but then", r"even so", r"on the other hand",
+        r"in contrast", r"nevertheless", r"nonetheless", r"still"
+    ],
+    "causal":   [r"because", r"so\b", r"therefore", r"thus", r"since\b"],
+    "shift":    [r"anyway", r"by the way", r"now,", r"ok,", r"okay,"],
+}
+DM_PAT = {k: re.compile(r"\b(?:%s)\b" % "|".join(v), re.I) for k, v in DM_LEX.items()}
+
+def per100(x: float, base: float, eps: float = 1e-9) -> float:
+    return 100.0 * x / (base + eps)
+
+def count_tokens(s: str) -> int:
+    return len(TOKEN_RE.findall(s or ""))
+
+def ms_total(text: str) -> int:
+    MS_VERBS = {"think","know","believe","guess","remember","forget","feel","want","hope",
+                "pretend","notice","decide","understand","suppose","realize","wish","doubt"}
+    MS_ADJS  = {"sure","afraid","glad","sorry","certain","uncertain","anxious","confident"}
+    MS_NOUNS = {"idea","plan","belief","memory","thought","feeling","desire","hope"}
+    toks=[t.lower() for t in TOKEN_RE.findall(text or "")]
+    return sum(t in MS_VERBS for t in toks) + sum(t in MS_ADJS for t in toks) + sum(t in MS_NOUNS for t in toks)
+
+def subject_from_filename(path: str) -> int | None:
+    """'asd_Nadig_101.cha' → 101 を返す（3桁優先）。"""
+    m=re.search(r"(\d{3})(?!\d)", os.path.basename(path))
+    return int(m.group(1)) if m else None
+
+def group_from_subject(subj: int) -> str | None:
+    """100番台=英語のみ、偶数=ASD/奇数=TYP。"""
+    if subj is None or not (100 <= subj < 200):
+        return None
+    return "ASD" if (subj % 2 == 0) else "TYP"
+
+def parse_cha_chi_metrics(path: str) -> dict:
+    """1つの .cha から CHI 指標を返す。"""
+    chi_utts=[]
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        for raw in f:
+            if raw.startswith("*CHI:"):
+                chi_utts.append(raw.split(":",1)[1])
+    n_utt=len(chi_utts)
+    tok_n=sum(count_tokens(u) for u in chi_utts)
+    is_whq=[bool(WH_RE.match(u)) for u in chi_utts]
+    is_qmark=[bool(QMARK_RE.search(u)) for u in chi_utts]
+    is_ynq=[qm and not wh for qm,wh in zip(is_qmark,is_whq)]
+    is_q_any=[a or b for a,b in zip(is_whq,is_ynq)]
+    dm_sum={k:sum(len(DM_PAT[k].findall(u)) for u in chi_utts) for k in DM_PAT}
+    ms_sum=sum(ms_total(u) for u in chi_utts)
+    return {
+        "q_all_rate": (sum(is_q_any)/n_utt) if n_utt>0 else 0.0,
+        "q_wh_rate":  (sum(is_whq)/n_utt)   if n_utt>0 else 0.0,
+        "q_yn_rate":  (sum(is_ynq)/n_utt)   if n_utt>0 else 0.0,
+        "dm_fill_per100utt":     per100(dm_sum["fill"], n_utt),
+        "dm_contrast_per100utt": per100(dm_sum["contrast"], n_utt),
+        "dm_causal_per100utt":   per100(dm_sum["causal"], n_utt),
+        "dm_shift_per100utt":    per100(dm_sum["shift"], n_utt),
+        "ms_total_per100w":      per100(ms_sum, tok_n if tok_n>0 else 1e-9),
+        "n_utt": n_utt, "tok_n": tok_n,
+    }
+
+def extract_subjects_from_dyads(dyads_csv: str) -> set[int]:
+    """dyads CSV から 3桁 subject を総当たり抽出（t2_files_used 等を横断）。"""
+    try:
+        dy = pd.read_csv(dyads_csv)
+    except Exception:
+        return set()
+    subs=set()
+    for col in dy.columns:
+        if dy[col].dtype == object:
+            for val in dy[col].astype(str).fillna(""):
+                for t in re.findall(r"(\d{3})(?!\d)", val):
+                    n=int(t)
+                    if 100 <= n < 200:
+                        subs.add(n)
+    return subs
+
+def hedges_g_from_groups(n1, m1, s1, n2, m2, s2):
+    """Hedges g とSE, 95%CI。n1=ASD, n2=TYP。"""
+    if (n1 is None) or (n2 is None) or (n1+n2 - 2) <= 0:
+        return np.nan, np.nan, np.nan, np.nan
+    sp = math.sqrt(((n1-1)*(s1**2) + (n2-1)*(s2**2)) / max(n1+n2-2, 1))
+    if sp == 0:
+        return np.nan, np.nan, np.nan, np.nan
+    d  = (m1 - m2) / sp
+    J  = 1 - 3/(4*(n1+n2)-9) if (n1+n2)>2 else 1.0
+    g  = J * d
+    se = math.sqrt((n1+n2)/(n1*n2) + (g*g)/(2*(n1+n2-2))) if (n1+n2-2)>0 else np.nan
+    lo, hi = (g - 1.96*se, g + 1.96*se) if not np.isnan(se) else (np.nan, np.nan)
+    return g, se, lo, hi
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument("--nadig_dir", required=True, help="例: data/raw/asd/Nadig")
+    ap.add_argument("--out_csv", required=True)
+    ap.add_argument("--byfile_out_csv", default="")
+    ap.add_argument("--meta_out", default="")
+    ap.add_argument("--restrict_to_dyads", default="", help="例: dyads.bn2015.full.csv（指定すると 11/11 subject に限定）")
+    args=ap.parse_args()
+
+    # 11/11 subject 抽出（任意）
+    restrict_subjects=set()
+    if args.restrict_to_dyads:
+        restrict_subjects = extract_subjects_from_dyads(args.restrict_to_dyads)
+        if restrict_subjects:
+            print(f"[INFO] Restricting to subjects from dyads ({len(restrict_subjects)}):",
+                  sorted(restrict_subjects))
+        else:
+            print(f"[WARN] Could not extract subjects from {args.restrict_to_dyads}. Proceeding without restriction.")
+
+    # .cha 収集
+    cha_files=sorted(glob.glob(os.path.join(args.nadig_dir, "*.cha")))
+    if not cha_files:
+        raise SystemExit(f"No .cha found in {args.nadig_dir}")
+
+    # 解析
+    rows=[]
+    for fp in cha_files:
+        subj=subject_from_filename(fp)
+        grp =group_from_subject(subj)  # None → 非英語/不正番号は除外
+        if grp is None:
+            continue
+        if restrict_subjects and (subj not in restrict_subjects):
+            continue
+        met=parse_cha_chi_metrics(fp)
+        met.update({"file": os.path.basename(fp), "subject": subj, "group": grp})
+        rows.append(met)
+
+    if not rows:
+        raise SystemExit("No English Nadig files matched the criteria. Check paths / dyads restriction.")
+
+    byfile=pd.DataFrame(rows)
+
+    # Subject内平均 → 群平均
+    metrics=["q_all_rate","q_wh_rate","q_yn_rate",
+             "dm_fill_per100utt","dm_contrast_per100utt","dm_causal_per100utt","dm_shift_per100utt",
+             "ms_total_per100w"]
+    per_subject=(byfile.groupby(["group","subject"])[metrics].mean().reset_index())
+
+    # 群平均テーブル
+    grp = (per_subject.groupby("group")[metrics].mean().round(6))
+    grp["n_dyads"]=per_subject.groupby("group")["subject"].nunique().astype(int)
+    grp = grp[["n_dyads"]+metrics].sort_index()
+
+    # 保存
+    os.makedirs(os.path.dirname(args.out_csv) or ".", exist_ok=True)
+    grp.reset_index().to_csv(args.out_csv, index=False)
+    print(f"Wrote {args.out_csv}  shape={grp.shape}")
+    print(grp.reset_index().to_string(index=False))
+
+    if args.byfile_out_csv:
+        os.makedirs(os.path.dirname(args.byfile_out_csv) or ".", exist_ok=True)
+        byfile.to_csv(args.byfile_out_csv, index=False)
+        print(f"Wrote {args.byfile_out_csv}  shape={byfile.shape}")
+
+    # メタ解析CSV（mean/sd/n と Hedges g）
+    if args.meta_out:
+        stats = per_subject.groupby("group")[metrics].agg(['mean','std','count'])
+        def mk_row(m):
+            n1 = int(stats.loc['ASD', (m,'count')]); m1 = float(stats.loc['ASD',(m,'mean')]); s1 = float(stats.loc['ASD',(m,'std')])
+            n2 = int(stats.loc['TYP', (m,'count')]); m2 = float(stats.loc['TYP',(m,'mean')]); s2 = float(stats.loc['TYP',(m,'std')])
+            g, se, lo, hi = hedges_g_from_groups(n1,m1,s1,n2,m2,s2)
+            return dict(metric=m,
+                        mean_ASD=m1, sd_ASD=s1, n_ASD=n1,
+                        mean_TYP=m2, sd_TYP=s2, n_TYP=n2,
+                        hedges_g=g, se=se, ci95_lo=lo, ci95_hi=hi)
+        meta = pd.DataFrame([mk_row(m) for m in metrics])
+        os.makedirs(os.path.dirname(args.meta_out) or ".", exist_ok=True)
+        meta.to_csv(args.meta_out, index=False)
+        print(f"Wrote {args.meta_out}  shape={meta.shape}")
+
+if __name__=="__main__":
+    main()


### PR DESCRIPTION
### 概要
- BN2015（英語）再現ダッシュボードを `docs/bn2015_dashboard.html` に追加
- CHI の語用論指標（ASD vs TYP）とメタ解析CSV（mean/sd/n + Hedges’ g, 95%CI）を反映
- 日本語 README 追加（目的・手順・指標定義・出典）
- 大容量データは含めず、再現は README の手順で可能

### 変更点
- add: make_dashboard.py（meta表セクション・引数 --prag_meta 追加）
- add: src/features/pragmatics_from_cha.py（--restrict_to_dyads / meta出力）
- add: docs/bn2015_dashboard.html / docs/index.html
- add: README_JA.md
- chore: .gitignore（data/, out/, reports/ など除外）

### 確認方法
- docs/bn2015_dashboard.html をブラウザで開く（Meta表が表示されること）
- README_JA.md の手順でローカル再生成可能

### 出典・注記
- TalkBank Nadig（偶数=ASD/奇数=TYP）
- Bang & Nadig (2015) の再現
- 語用論レビュー3本の要約に基づき指標選定（追ってDOI追記）
